### PR TITLE
뷰포트 가로 너비 넘쳐나는 문제 해결하기

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -270,7 +270,11 @@ fieldset.row-box {
 
 .inner-box {
   display: flex;
-  padding: 48px 84px 18px 84px;
+
+  padding-inline: clamp(16px, 8vw, 84px); /* 좌/우: 16px ~ 84px */
+  padding-block-start: clamp(24px, 5vmin, 48px); /* 위: 24px ~ 48px */
+  padding-block-end: clamp(12px, 3vmin, 18px); /* 아래: 12px ~ 18px */
+
   flex-direction: column;
   align-items: center;
   gap: 48px;
@@ -281,10 +285,6 @@ fieldset.row-box {
 
 .tab-list {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 24px;
-  align-self: stretch;
   list-style: none; /* ul 기본 점 제거 */
   padding: 0;
   margin: 0;
@@ -292,10 +292,13 @@ fieldset.row-box {
 
 .tab-button {
   display: flex;
-  padding: 8px 40px;
+
+  /* 가변 패딩으로 작은 가로 뷰포트에서 축소하기 */
+  padding-block: clamp(6px, 1.5vmin, 8px);
+  padding-inline: clamp(8px, 3.5vw, 16px);
+
   justify-content: center;
   align-items: center;
-  width: auto;
   background: rgba(255, 255, 255, 0);
   border: none;
   border-radius: 8px;
@@ -328,7 +331,8 @@ fieldset.row-box {
 .timer-display {
   color: #fff;
   text-align: center;
-  font-size: 128px;
+  /* 뷰포트 기준: 최소 48px ~ 최대 128px */
+  font-size: clamp(48px, 14vw, 128px);
   font-style: normal;
   font-weight: 400;
   line-height: 100%; /* 128px */
@@ -345,7 +349,10 @@ fieldset.row-box {
 
 .start-button {
   display: inline-flex;
-  padding: 14px 0;
+
+  padding-inline: 0;
+  padding-block: clamp(8px, 2vw, 14px);
+
   justify-content: center;
   align-items: center;
   width: 100%;


### PR DESCRIPTION
| 화면 가로 너비 1000px | 375px (iPhone SE2) |
|--|--|
| <img width="1000" height="800" alt="Screen Shot 2025-10-29 at 14 04 26" src="https://github.com/user-attachments/assets/a30633b0-61c0-40cf-bef2-b488210f1e19" /> | <img width="383" height="680" alt="Screen Shot 2025-10-29 at 14 04 47" src="https://github.com/user-attachments/assets/c0de6eb9-a58b-4eee-b2e0-207eebff543b" /> |


피그마 목업에 고려된 최소 뷰포트의 가로 너비가 680px 인데요, 그 이하의 크기에 넘쳐나는 문제입니다.

각 요소별 고정된 패딩값을 뷰포트에 따라 가변적으로 수정을 했습니다. 논의 및 협의가 필요한 변경으로 파악되어서 초안으로 올렸습니다.