### PR TITLE
fix: 타이머 숫자 변경 시 컨테이너 가로 너비가 흔들리던 문제 수정

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -325,7 +325,7 @@ fieldset.row-box {
   flex-direction: column;
   align-items: center;
   gap: 18px;
-  width: 100%;
+  width: min(36vw, 400px);
 }
 
 .timer-display {
@@ -396,6 +396,7 @@ main.app[data-timer-state='running'] .start-button::before {
   line-height: 100%; /* 20px */
   letter-spacing: -0.44px;
   margin: 0; /* <p> 자체의 마진 제거 */
+  word-break: keep-all;
 }
 
 .setting-guide.is-hidden {


### PR DESCRIPTION
- 원인: 컨테이너 폭이 내용 너비(숫자 글리프 폭)에 종속되어 tick마다 레이아웃 시프트 발생
- 조치: 컨테이너(.frame) 가로 너비를 내용 너비보다 크게 설정하기. 뷰포트 비례 + 상한 적용(width: min(36vw, 400px))
- 결과: 타이머 숫자 변경 시에도 컨테이너 너비가 훨씬 더 크기에 화면 흔들림이 제거되었습니다.
