### PR TITLE
fix: 시간 설정 모달이 뷰포트를 벗어나는 문제 해결하기

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,32 +35,27 @@
             </button>
           </header>
           <fieldset class="row-box">
-            <div>
-              <label for="work-time">활동 시간</label>
-              <input id="work-time" inputmode="numeric" placeholder="25:00" />
-            </div>
-            <div>
-              <label for="break-time">휴식 시간</label>
-              <input id="break-time" inputmode="numeric" placeholder="05:00" />
-            </div>
-            <div>
-              <label for="cycle">주기</label>
-              <input
-                id="cycle"
-                name="cycle"
-                type="number"
-                placeholder="1"
-                min="1"
-              />
-            </div>
-            <div>
-              <label for="long-break-time">긴 휴식 시간</label>
-              <input
-                id="long-break-time"
-                inputmode="numeric"
-                placeholder="15:00"
-              />
-            </div>
+            <label for="work-time">활동 시간</label>
+            <input id="work-time" inputmode="numeric" placeholder="25:00" />
+
+            <label for="break-time">휴식 시간</label>
+            <input id="break-time" inputmode="numeric" placeholder="05:00" />
+
+            <label for="cycle">주기</label>
+            <input
+              id="cycle"
+              name="cycle"
+              type="number"
+              placeholder="1"
+              min="1"
+            />
+
+            <label for="long-break-time">긴 휴식 시간</label>
+            <input
+              id="long-break-time"
+              inputmode="numeric"
+              placeholder="15:00"
+            />
           </fieldset>
           <button type="submit" id="generateBtn" class="generate-row"></button>
         </div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -92,8 +92,9 @@ label[for='create-timer'] {
 #setting-timer {
   position: relative;
   display: flex;
-  width: 620px;
-  padding: 24px;
+  max-width: 620px;
+  padding: clamp(16px, 4vw, 24px);
+  margin: clamp(16px, 4vw, 24px);
   flex-direction: column;
   align-items: center;
   gap: 18px;
@@ -143,59 +144,43 @@ label[for='create-timer'] {
 }
 
 fieldset.row-box {
+  margin: 0;
+  padding: 0 34px;
   border: none;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 20px;
 
-  > div {
-    display: flex;
-    width: 503px;
-    justify-content: space-between;
-    align-items: center;
+  display: grid;
+  gap: 20px 10px;
+  font-size: clamp(1.25rem, 4vw, 24px);
 
-    > label {
-      width: 118px;
-      height: 37px;
-      flex-shrink: 0;
-      text-align: right;
-      font-family: BMJUA;
-      font-size: 24px;
-      font-style: normal;
-      font-weight: 400;
-      line-height: 150%;
-      letter-spacing: -0.528px;
-    }
+  grid-template-columns: minmax(max-content, 1fr) minmax(0, 3fr);
 
-    > input {
-      display: flex;
-      width: 375px;
-      padding: 8px 0;
-      justify-content: center;
-      align-items: center;
-      flex-shrink: 0;
-      border: none;
-      background: rgba(255, 255, 255, 0.3);
-      border-radius: 8px;
-      box-shadow: 0 8px 12px 6px rgba(0, 0, 0, 0.15),
-        0 4px 4px 0 rgba(0, 0, 0, 0.3);
-      /* flex: 1 0 0; */
+  > label {
+    text-align: right;
+    align-self: center;
+    font-weight: 400;
+    letter-spacing: -0.528px;
+  }
+
+  > input {
+    padding-block: clamp(6px, 2.5vmin, 8px);
+    border: none;
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 8px;
+    box-shadow: 0 8px 12px 6px rgba(0, 0, 0, 0.15),
+      0 4px 4px 0 rgba(0, 0, 0, 0.3);
+    color: currentColor;
+
+    &::placeholder {
       color: currentColor;
-
-      &::placeholder {
-        color: currentColor;
-        opacity: 0.4;
-      }
-
-      text-align: center;
-      font-family: BMJUA;
-      font-size: 48px;
-      font-style: normal;
-      font-weight: 400;
-      line-height: 100%;
-      letter-spacing: -1.056px;
+      opacity: 0.4;
     }
+
+    text-align: center;
+    font-size: 2em;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 100%;
+    letter-spacing: -1.056px;
   }
 }
 


### PR DESCRIPTION
- `#setting-timer`: width(고정) → `max-width(620px)` + padding 을 가변화함
- 아래 두 하위 설정을 적용하고자 `fieldset.row-box` 컨테이너의 레이아웃 방식을 Grid 변경
  - `grid-template-columns: minmax(max-content, 1fr) minmax(0, 3fr)`
  - 고정 폭 제거, 간격/패딩 가변화
- input: padding 을 가변화하고자 `padding-block: clamp(6px, 2.5vmin, 8px)` 로 설정, 글자 크기는 레이블 크기에 비해 두배 `2em` 로 설정하기


| 670px 가로 뷰포트 | 375px 가로 뷰포트 (iPhone SE2) |
|--|--|
| <img alt="Screen Shot 2025-10-31 at 16 14 11" src="https://github.com/user-attachments/assets/e2fcee04-9ff7-4012-a4c6-d7fbc0d55c11" /> | <img alt="Screen Shot 2025-10-31 at 16 14 22" src="https://github.com/user-attachments/assets/80eba793-7cd9-427f-a703-13cf956f175c" /> |

이제 작은 뷰포트(예: iPhone SE2)에서 모달 내부 콘텐츠가 좌우로 넘치지 않고 제대로 보여집니다.