### PR TITLE
improve: 긴 휴식 시간이 되었을 때 메시지 변경을 data-timer-state로 구현

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -400,6 +400,11 @@ main.app[data-timer-state='running'] .setting-guide::before {
   content: '타이머 주기: ' attr(data-cycle-context);
 }
 
+main.app[data-timer-state='long-break'] .setting-guide::before {
+  color: #fff;
+  content: '긴 휴식 시간입니다. 재정비하세요.';
+}
+
 #ipsum {
   color: black;
 }

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -51,7 +51,10 @@ export default class Timer {
   }
 
   isTimerRunning() {
-    return this.mainApp.dataset.timerState === 'running';
+    return (
+      this.mainApp.dataset.timerState === 'running' ||
+      this.mainApp.dataset.timerState === 'long-break'
+    );
   }
 
   stopTimer() {
@@ -105,6 +108,7 @@ export default class Timer {
           this.changeState(State.WORK);
           this.currentCycle--;
         } else {
+          this.mainApp.dataset.timerState = 'long-break';
           this.changeState(State.LONG_BREAK);
           showNotification('모든 주기 종료\n긴 휴식 시작!');
         }


### PR DESCRIPTION
긴 휴식 시간이 되었는데도 기존 "주기: 1/3" 같은 메시지가 남아있어서 (실제로 주기는 0으로 마무리가 되었는데도.) 이를 휴식하라는 메시지로 변경